### PR TITLE
Frequency array must be reset using array values

### DIFF
--- a/Longest Consecutive Nums Subarray.cpp
+++ b/Longest Consecutive Nums Subarray.cpp
@@ -11,7 +11,7 @@ int longestConsecNumsSubarray() {
     int ans = 0;
     for(int Left = 1; Left <= n; Left++) {
         for(int i = 1; i <= n; i++)
-            fr[i] = false;
+            fr[a[i]] = false;
         int Min = a[Left], Max = a[Left];
         for(int Right = Left; Right <= n; Right++) {
             if(fr[a[Right]] == true)


### PR DESCRIPTION
The current implementation resets the first n values of the frequency array. However, it should be using the values of the input array to reset. For example, the current implementation fails with an array of [1, 1, 1, 27, 28], producing a result of 1. The change produces the correct output of 2.